### PR TITLE
26 create standalone bundle for desktop distribution

### DIFF
--- a/.github/workflows/desktop-bundles.yml
+++ b/.github/workflows/desktop-bundles.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-desktop:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read      # Needed to read repo contents
+      id-token: write     # Required for OIDC token to generate provenance
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/desktop-bundles.yml
+++ b/.github/workflows/desktop-bundles.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           echo "Listing dist directory"
           ls -R dist || true
-          # Upload entire dist for now
-          echo "::set-output name=distpath::dist"
+          # Upload entire dist for now; expose path via GITHUB_OUTPUT
+          echo "distpath=dist" >> "$GITHUB_OUTPUT"
 
       - name: Upload bundle artifacts
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.3"
 requires-python = ">=3.10"
 description = "Python port (in progress) of the Turbo Pascal Pohualli calendrical utility"
 authors = [ { name = "Port Maintainers" } ]
-license = "GPL-3.0-only"
+license = { file = "LICENSE" }
 readme = "README.md"
 keywords = ["maya","aztec","calendar","mesoamerican","astronomy","long-count","tzolkin","haab"]
 classifiers = [


### PR DESCRIPTION
- **ci(desktop): add OIDC permissions for build provenance attestation**
- **chore(build): switch to PEP 621 license.file format**
- **ci(desktop): replace deprecated set-output with GITHUB_OUTPUT**
