### PR TITLE
Release 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pohualli"
-version = "0.2.3"
+version = "0.2.4"
 requires-python = ">=3.10"
 description = "Python port (in progress) of the Turbo Pascal Pohualli calendrical utility"
 authors = [ { name = "Port Maintainers" } ]
@@ -67,7 +67,7 @@ author = "Port Maintainers"
 [tool.briefcase.app.pohualli]
 formal_name = "Pohualli"
 description = "Mesoamerican calendar utility (Maya and Aztec calendrics)."
-version = "0.2.3"
+version = "0.2.4"
 sources = ["pohualli"]
 main_module = "pohualli.desktop_app"
 requires = [


### PR DESCRIPTION
Release 0.2.4

Changes:
- Bump version to 0.2.4
- Desktop bundle workflow: macOS/Windows packaging & release asset publishing
- Added PyPI vs Desktop install instructions (README, docs)
- Added __main__ entry point for bundled execution
- README structure tree updates & release links

After merge: tag already pushed (v0.2.4); verify release assets and publish PyPI if not automated.