### PR TITLE
feat(web): async range jobs, cancel support, CLI range search, UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ pohualli load-config config.json
 
 # Full JSON composite into a file
 pohualli from-jdn 2451545 --json > composite.json
+
+# Range search (scan inclusive JDN interval with filters)
+# Find first 5 dates in a span whose Tzolkin name is Imix and Haab month is Cumhu
+pohualli search-range 584283 584500 --tzolkin-name Imix --haab-month Cumhu --limit 5
+
+# Long Count pattern matching (use * as wildcard for a component)
+pohualli search-range 500000 600000 --long-count '9.*.*.*.*.*' --limit 3
+
+# Output JSON lines (machine processing)
+pohualli search-range 584283 584400 --tzolkin-value 4 --json-lines --limit 2
+
+# Select custom output fields
+pohualli search-range 584283 584400 --fields jdn,tzolkin_name,haab_month_name --limit 3
+
+# Switch to Aztec year-bearer derivation (subtracts 364 days in interval logic)
+pohualli from-jdn 2451545 --culture aztec --year-bearer-ref 0 0
+
+# Range search in Aztec mode
+pohualli search-range 584283 584400 --culture aztec --tzolkin-value 4 --limit 2
 ```
 
 ## Web App
@@ -170,6 +189,9 @@ pytest -q
 
 ## License
 GPL-3.0-only
+
+### Maya vs Aztec Year Bearer Note
+The computation of the Year Bearer differs: in Aztec (tonalpohualli) mode the interval between the target Haab position and the reference is reduced by 364 days before deriving the bearer, shifting the resulting Tzolkin pair relative to Maya convention. Use `--culture aztec` (CLI) or the Culture dropdown in the web UI to toggle. Default is Maya.
 
 ## Reference
 Sołtysiak, A. & Lebeuf, A. (2011). Pohualli 1.01. A computer simulation of Mesoamerican calendar systems. 8(49), 165–168. [ResearchGate](https://www.researchgate.net/publication/270956742_2011_Pohualli_101_A_computer_simulation_of_Mesoamerican_calendar_systems)

--- a/pohualli/autocorr.py
+++ b/pohualli/autocorr.py
@@ -209,13 +209,17 @@ def derive_auto_corrections(
             raise ValueError('Long Count must have 5 or 6 components separated by dots')
         target = tuple(lc_numbers)
         found = False
-        for off in range(-5000, 5001):
-            if _long_count_with_offset(jdn, off) == target:
-                lcd_offset = off
-                found = True
+        # Adaptive widening: first a quick small window, then a large window if needed.
+        for window in (5000, 200000):
+            for off in range(-window, window + 1):
+                if _long_count_with_offset(jdn, off) == target:
+                    lcd_offset = off
+                    found = True
+                    break
+            if found:
                 break
         if not found:
-            raise ValueError('Unable to match long count within search window')
+            raise ValueError(f'Unable to match long count within ±200000 day offset of JDN {jdn}')
 
     # Year bearer reference
     yb_month = None

--- a/pohualli/cli.py
+++ b/pohualli/cli.py
@@ -22,6 +22,7 @@ def main(argv=None):
     conv.add_argument("--year-bearer-ref", nargs=2, type=int, metavar=("MONTH","DAY"), help="Reference Year Bearer Haab month/day (default from config)")
     conv.add_argument("--new-era", type=int, help="Override New Era (base JDN for Long Count)")
     conv.add_argument("--json", action='store_true', help="Output JSON composite result")
+    conv.add_argument("--culture", choices=['maya','aztec'], help="Year bearer culture; Aztec mode subtracts 364 days before deriving bearer (default Maya)")
     confs = sub.add_parser("save-config", help="Save current configuration to file")
     confs.add_argument("path", help="Path to JSON config file")
     confl = sub.add_parser("load-config", help="Load configuration from file")
@@ -39,6 +40,25 @@ def main(argv=None):
     ac.add_argument('--cycle819-station', type=int)
     ac.add_argument('--cycle819-value', type=int)
     ac.add_argument('--dir-color')
+    # --- range search ---
+    sr = sub.add_parser('search-range', help='Scan an inclusive JDN range and filter matching calendrical criteria')
+    sr.add_argument('start', type=int, help='Start JDN (inclusive)')
+    sr.add_argument('end', type=int, help='End JDN (inclusive)')
+    sr.add_argument('--tzolkin-value', type=int, help='Filter: Tzolkin value (1..13)')
+    sr.add_argument('--tzolkin-name', help='Filter: Tzolkin day name (case-insensitive)')
+    sr.add_argument('--haab-day', type=int, help='Filter: Haab day number (0..19 Maya / 1..20 Aztec)')
+    sr.add_argument('--haab-month', help='Filter: Haab month name (case-insensitive)')
+    sr.add_argument('--year-bearer-name', help='Filter: Year bearer Tzolkin name (case-insensitive)')
+    sr.add_argument('--dir-color', help='Filter: Direction/Color string (substring match)')
+    sr.add_argument('--weekday', type=int, choices=list(range(1,8)), help='Filter: ISO weekday (1=Mon .. 7=Sun)')
+    sr.add_argument('--long-count', help="Filter: Long Count pattern e.g. '13.*.*.*.*.*' (use * as wildcard segment)")
+    sr.add_argument('--limit', type=int, help='Stop after this many matches')
+    sr.add_argument('--json-lines', action='store_true', help='Output JSON per line instead of table')
+    sr.add_argument('--fields', help='Comma list of fields for table output (default preset)')
+    sr.add_argument('--progress-every', type=int, default=0, help='Emit a progress line every N days scanned (stderr)')
+    sr.add_argument('--step', type=int, default=1, help='Increment JDN by this step (default 1)')
+    sr.add_argument('--perf-stats', action='store_true', help='Emit performance stats (stderr) at end: scanned vs composite calls')
+    sr.add_argument('--culture', choices=['maya','aztec'], help='Year bearer culture toggle (affects year bearer derivation)')
     args = p.parse_args(argv)
 
     if args.cmd == "from-jdn":
@@ -47,6 +67,8 @@ def main(argv=None):
             ABSOLUTE.new_era = args.new_era
         if args.year_bearer_ref:
             DEFAULT_CONFIG.year_bearer_str, DEFAULT_CONFIG.year_bearer_val = args.year_bearer_ref
+        if getattr(args, 'culture', None):
+            DEFAULT_CONFIG.t_aztec = (args.culture == 'aztec')
         if args.json:
             comp = compute_composite(jdn)
             print(json.dumps(comp.to_dict(), indent=2, sort_keys=True))
@@ -64,6 +86,7 @@ def main(argv=None):
             print(f"Haab: {haab_day} {haab_number_to_name(haab_month)} (monthIndex={haab_month})")
             print(f"Long Count: {'.'.join(str(x) for x in lc)} (NewEra={ABSOLUTE.new_era})")
             print(f"Year Bearer packed: 0x{yb:04X} (nameIndex={yb>>8}, value={yb & 0xFF})")
+            print(f"Year Bearer culture: {'Aztec' if DEFAULT_CONFIG.t_aztec else 'Maya'}" + (" (Aztec mode uses interval-364 adjustment)" if DEFAULT_CONFIG.t_aztec else ""))
     elif args.cmd == "save-config":
         save_config(args.path)
     elif args.cmd == "load-config":
@@ -87,6 +110,121 @@ def main(argv=None):
             dir_color=args.dir_color,
         )
         print(json.dumps(res.__dict__, indent=2, sort_keys=True))
+    elif args.cmd == 'search-range':
+        start, end = args.start, args.end
+        if start > end:
+            start, end = end, start
+        step = args.step if args.step and args.step > 0 else 1
+        if getattr(args, 'culture', None):
+            DEFAULT_CONFIG.t_aztec = (args.culture == 'aztec')
+        # Prepare filters (lowercased for case-insensitive)
+        tz_name = args.tzolkin_name.lower() if args.tzolkin_name else None
+        haab_month = args.haab_month.lower() if args.haab_month else None
+        yb_name = args.year_bearer_name.lower() if args.year_bearer_name else None
+        dir_color_f = args.dir_color.lower() if args.dir_color else None
+        lc_pattern = args.long_count.split('.') if args.long_count else None
+        def match_lc(lc_tuple):
+            if not lc_pattern:
+                return True
+            if len(lc_pattern) != len(lc_tuple):
+                return False
+            for pat, val in zip(lc_pattern, lc_tuple):
+                if pat != '*' and pat != str(val):
+                    return False
+            return True
+        # Choose output fields
+        default_fields = ['jdn','gregorian_date','tzolkin_value','tzolkin_name','haab_day','haab_month_name','long_count','year_bearer_name','dir_color_str']
+        fields = [f.strip() for f in (args.fields.split(',') if args.fields else default_fields)]
+        count = 0
+        total = ((end - start) // step) + 1
+        composite_calls = 0
+        # Iterate range with early (cheap) filters before constructing full composite
+        for i, jdn in enumerate(range(start, end+1, step), start=1):
+            # Early filtering using individual conversion functions to avoid full composite cost
+            # Only compute the pieces actually required by specified filters.
+            # Tzolkin filters
+            if args.tzolkin_value or tz_name:
+                tzv_early = julian_day_to_tzolkin_value(jdn)
+                if args.tzolkin_value and tzv_early != args.tzolkin_value:
+                    if args.progress_every and (i % args.progress_every == 0):
+                        import sys
+                        print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                    continue
+                if tz_name:
+                    tzn_idx_early = julian_day_to_tzolkin_name_index(jdn)
+                    if tzolkin_number_to_name(tzn_idx_early).lower() != tz_name:
+                        if args.progress_every and (i % args.progress_every == 0):
+                            import sys
+                            print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                        continue
+            # Haab filters
+            need_haab = (args.haab_day is not None) or haab_month or yb_name
+            if need_haab:
+                haab_packed = julian_day_to_haab_packed(jdn)
+                h_month_idx = unpack_haab_month(haab_packed)
+                h_day_val = unpack_haab_value(haab_packed)
+                if args.haab_day is not None and h_day_val != args.haab_day:
+                    if args.progress_every and (i % args.progress_every == 0):
+                        import sys
+                        print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                    continue
+                if haab_month and haab_number_to_name(h_month_idx).lower() != haab_month:
+                    if args.progress_every and (i % args.progress_every == 0):
+                        import sys
+                        print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                    continue
+                if yb_name:
+                    # Year bearer name is derived from haab month/day and JDN
+                    yb = year_bearer_packed(h_month_idx, h_day_val, jdn)
+                    yb_name_early = tzolkin_number_to_name(yb >> 8).lower()
+                    if yb_name_early != yb_name:
+                        if args.progress_every and (i % args.progress_every == 0):
+                            import sys
+                            print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                        continue
+            # Long Count filter (pattern) early
+            if lc_pattern:
+                lc_early = julian_day_to_long_count(jdn)
+                if not match_lc(lc_early):
+                    if args.progress_every and (i % args.progress_every == 0):
+                        import sys
+                        print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+                    continue
+            # At this point all early filters passed; build composite (expensive) only once
+            comp = compute_composite(jdn)
+            composite_calls += 1
+            # Remaining filters that currently require composite fields
+            if dir_color_f and dir_color_f not in comp.dir_color_str.lower():
+                continue
+            if args.weekday and comp.iso_weekday != args.weekday:
+                continue
+            # (Long count was already evaluated if pattern provided)
+            count += 1
+            if args.json_lines:
+                print(json.dumps(comp.to_dict(), sort_keys=True))
+            else:
+                row_vals = []
+                for f in fields:
+                    v = getattr(comp, f, '')
+                    if isinstance(v, (list, tuple)):
+                        v = '.'.join(str(x) for x in v)
+                    row_vals.append(str(v))
+                if count == 1 and not args.json_lines:
+                    print('\t'.join(fields))
+                print('\t'.join(row_vals))
+            if args.limit and count >= args.limit:
+                break
+            if args.progress_every and (i % args.progress_every == 0):
+                import sys
+                print(f"# progress {i}/{total} ({(i/total)*100:.1f}%) matches={count}", file=sys.stderr)
+        # If no matches and not JSON mode, optionally print header
+        if count == 0 and not args.json_lines:
+            print("# no matches")
+        if args.perf_stats:
+            import sys
+            scanned = ((end - start) // step) + 1
+            saved = scanned - composite_calls
+            print(f"# perf scanned={scanned} composite_calls={composite_calls} saved={saved} matches={count}", file=sys.stderr)
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/pohualli/templates/index.html
+++ b/pohualli/templates/index.html
@@ -8,6 +8,23 @@
 (function(){
   try { var th = localStorage.getItem('pohualli_theme'); if(th){ document.documentElement.setAttribute('data-theme', th); } } catch(e){}
 })();
+// Preserve scroll position across full page reloads (form submissions)
+(function(){
+  const KEY='pohualli_scroll_y';
+  // When a submit button is clicked, store current scroll position
+  document.addEventListener('click', function(ev){
+    const btn = ev.target && ev.target.closest('button');
+    if(!btn) return;
+    if(btn.type === 'submit'){ sessionStorage.setItem(KEY, String(window.scrollY)); }
+  }, true);
+  // On load, restore and then clear
+  window.addEventListener('DOMContentLoaded', function(){
+    try {
+      const y = sessionStorage.getItem(KEY);
+      if(y){ window.scrollTo(0, parseInt(y,10)||0); sessionStorage.removeItem(KEY); }
+    } catch(_){}
+  });
+})();
 </script>
 <style>
 /* --- Color System (basic palette) --- */
@@ -106,6 +123,21 @@ footer { margin-top:2.5rem; font-size:.8rem; color:var(--color-text-soft); text-
 .card h3 { margin:.1rem 0 .45rem; font-size:.8rem; letter-spacing:.6px; font-weight:700; text-transform:uppercase; color: var(--color-text-soft); }
 .value { font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; font-size:.95rem; word-break:break-word; }
 details { border-radius:var(--radius-lg); background:linear-gradient(145deg,var(--color-panel),var(--color-panel-alt)); border:1px solid var(--color-border); box-shadow:var(--shadow-sm); }
+/* Themed panel wrapper to avoid hard-coded white backgrounds */
+.panel { background:linear-gradient(155deg,var(--color-panel),var(--color-panel-alt)); border:1px solid var(--color-border); border-radius:var(--radius-lg); box-shadow:var(--shadow-sm); }
+.panel h2 { margin-top:0; }
+.panel p { color: var(--color-text-soft); }
+:root[data-theme='light'] .panel { background: var(--color-panel); }
+:root:not([data-theme='light']) .panel { background:linear-gradient(155deg,#1a222b,#202a35 55%, #182027); }
+.panel table { width:100%; border-collapse:collapse; }
+.panel table thead th { background:rgba(255,255,255,0.06); font-weight:600; }
+:root[data-theme='light'] .panel table thead th { background:#f2f6fa; }
+.panel table tbody tr:nth-child(even){ background:rgba(255,255,255,0.04); }
+:root[data-theme='light'] .panel table tbody tr:nth-child(even){ background:#f5f9fc; }
+.panel table tbody tr:nth-child(odd){ background:rgba(255,255,255,0.015); }
+:root[data-theme='light'] .panel table tbody tr:nth-child(odd){ background:#ffffff; }
+.panel table td, .panel table th { padding:.35rem .5rem; border-bottom:1px solid var(--color-border-soft); }
+.panel .note { font-size:.65rem; color: var(--color-text-soft); }
 details[open] { box-shadow:var(--shadow-md); }
 details > summary { padding:.9rem 1.05rem; list-style:none; cursor:pointer; font-weight:600; letter-spacing:.4px; color: var(--color-text-soft); }
 details > summary::-webkit-details-marker { display:none; }
@@ -131,6 +163,15 @@ details form input { background:#141a22; }
   form { grid-template-columns: repeat(auto-fill,minmax(170px,1fr)); }
   .grid { grid-template-columns: repeat(auto-fill,minmax(170px,1fr)); }
 }
+/* --- Enhanced progress bar styles --- */
+.pbar-wrap { position:relative; background:#13202a; border:1px solid #2e3f4c; height:18px; border-radius:10px; overflow:hidden; box-shadow: inset 0 0 4px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,0.03); }
+.pbar { height:100%; background:linear-gradient(90deg,#1f6ad6,#2d83f4,#4a9bff); background-size:200% 100%; position:relative; transition:width .35s ease; display:flex; align-items:center; justify-content:center; font-size:.65rem; font-weight:600; letter-spacing:.5px; color:#fff; text-shadow:0 1px 2px rgba(0,0,0,.6); animation:pbarShift 3s linear infinite; }
+.pbar::after { content:""; position:absolute; inset:0; background:repeating-linear-gradient(45deg,rgba(255,255,255,0.18) 0 8px, rgba(255,255,255,0) 8px 16px); mix-blend-mode:overlay; opacity:.55; }
+@keyframes pbarShift { 0% {background-position:0 0;} 100% {background-position:200% 0;} }
+:root .pbar-done { animation:none !important; }
+.pbar-static { animation:none !important; }
+:root[data-theme='light'] .pbar-wrap { background:#f2f7fa; border-color:#c8d5e0; }
+:root[data-theme='light'] .pbar { text-shadow:none; }
 </style>
 <script>
 // --- Persistence of correction and config fields via localStorage ---
@@ -272,13 +313,304 @@ async function runAutocorr(){
   pre.style.display='block';
   pre.textContent='Calculating...';
   const resp = await fetch('/api/derive-autocorr?' + params.toString());
-  if(resp.ok){
-    const data = await resp.json();
+  let data = null; let rawText = '';
+  try { data = await resp.clone().json(); } catch(_) { try { rawText = await resp.text(); } catch(_){} }
+  if(resp.ok && data){
     pre.textContent = JSON.stringify(data, null, 2);
   } else {
-    pre.textContent = 'Error: ' + resp.status;
+    const errMsg = data && (data.error || data.detail) ? (data.error || data.detail) : (rawText.trim() || 'HTTP '+resp.status);
+    pre.textContent = 'Error: ' + errMsg;
   }
 }
+
+// -------- Asynchronous Range Job UI ---------
+let activeJobId = null;
+let pollTimer = null;
+let elapsedTimer = null; // client-side smoother elapsed updates
+let activeJobStartedEpoch = null; // unix seconds from server
+async function startRangeJob(ev){
+  ev.preventDefault();
+  if(pollTimer){ clearInterval(pollTimer); pollTimer=null; }
+  const form = ev.target;
+  const payload = {};
+  const map = {
+    start: 'r_start', end: 'r_end', step: 'r_step', limit:'r_limit', tzolkin_value:'r_tzval', tzolkin_name:'r_tzname', haab_day:'r_haab_day', haab_month:'r_haab_month', year_bearer_name:'r_year_bearer_name', dir_color:'r_dir_color', weekday:'r_weekday', long_count:'r_long_count', fields:'r_fields'
+  };
+  const box = document.getElementById('rangeJobBox');
+  box.textContent = 'Submitting job...';
+  for(const [api, field] of Object.entries(map)){
+    const el = form.querySelector(`[name="${field}"]`);
+  if(el && el.value.trim() !== '') payload[api] = el.value.trim();
+  }
+  const btn = form.querySelector('button[type="submit"]');
+  btn.disabled = true; btn.textContent='Starting...';
+  try{
+  const resp = await fetch('/api/range-jobs', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+    const data = await resp.json();
+    activeJobId = data.id;
+  activeJobStartedEpoch = data.started || null;
+  const stopBtn = document.getElementById('btnStopJob'); if(stopBtn){ stopBtn.disabled=false; }
+    renderJobStatus(data);
+    pollTimer = setInterval(pollStatus, 750);
+  startElapsedLoop();
+  }catch(e){
+    renderJobError(String(e));
+  } finally {
+    btn.disabled=false; btn.textContent='Search Range';
+  }
+}
+let _lastExampleIdx = {convert:-1, autocorr:-1, sync:-1, async:-1};
+function _pickExample(kind, arr){
+  if(!Array.isArray(arr) || !arr.length) return null;
+  let idx = Math.floor(Math.random()*arr.length);
+  if(arr.length>1 && idx === _lastExampleIdx[kind]){ idx = (idx+1)%arr.length; }
+  _lastExampleIdx[kind] = idx;
+  return arr[idx];
+}
+function fillAsyncExample(){
+  const f = document.getElementById('asyncRangeForm');
+  if(!f) return;
+  const examples = [
+    {start:'2451545', end:'2452000', tz:'Ik', limit:'12', fields:'jdn,gregorian_date,tzolkin_name,long_count'},
+    {start:'584283', end:'584900', tz:'Ahau', limit:'7', fields:'jdn,gregorian_date,haab_month_name,tzolkin_name'},
+    {start:'1872000', end:'1872600', tz:'Ben', limit:'9', fields:'jdn,gregorian_date,year_bearer_name'},
+    {start:'2305447', end:'2306000', tz:'Caban', limit:'6', fields:'jdn,gregorian_date,tzolkin_value,tzolkin_name'}
+  ];
+  const pick = _pickExample('async', examples);
+  if(!pick) return;
+  const set=(n,v)=>{ const el=f.querySelector(`[name="${n}"]`); if(el) el.value=v; };
+  set('r_start', pick.start);
+  set('r_end', pick.end);
+  set('r_limit', pick.limit);
+  set('r_tzname', pick.tz);
+  set('r_fields', pick.fields);
+  flashStatus('Async range example loaded');
+}
+
+// ---- Additional Example Fillers ----
+function fillConvertExample(){
+  const examples = [
+    { jdn: '2451545', label:'J2000.0' },
+    { jdn: '2440588', label:'Unix Epoch' },
+    { jdn: '584283', label:'GMT Base' },
+    { jdn: '1872000', label:'12.0.0.0.0' },
+    { jdn: '2305447', label:'9.9.16.0.0' }
+  ];
+  const pick = _pickExample('convert', examples);
+  if(!pick) return;
+  const jdn = document.getElementById('jdn');
+  if(jdn) jdn.value = pick.jdn;
+  const ybm = document.getElementById('ybm'); if(ybm) ybm.value='';
+  const ybd = document.getElementById('ybd'); if(ybd) ybd.value='';
+  flashStatus(`Example conversion loaded (${pick.label})`);
+}
+function fillCorrectionsExample(){
+  const map = {
+    tz_off: '0',
+    tzn_off: '0',
+    haab_off: '0',
+    g_off: '0',
+    lcd_off: '0',
+    week_off: '0',
+    c819s: '0',
+    c819d: '0'
+  };
+  for(const [k,v] of Object.entries(map)){
+    const el = document.querySelector(`[name="${k}"]`); if(el) el.value = v;
+  }
+  flashStatus('Example corrections loaded (all zero)');
+}
+function fillAutocorrExample(){
+  const jdnInput = document.getElementById('jdn');
+  const set = (id,val)=>{ const el=document.getElementById(id); if(el) el.value=val; };
+  async function loadFromJdn(jdn){
+    try {
+      const resp = await fetch('/api/convert?jdn=' + jdn);
+      if(!resp.ok) throw new Error('bad status');
+      const data = await resp.json();
+      // Build specs directly from composite so they always match this JDN
+      set('ac_tz', `${data.tzolkin_value} ${data.tzolkin_name}`);
+      set('ac_h', `${data.haab_day} ${data.haab_month_name}`);
+      // g value not exposed separately; leave blank so derivation can compute others without stricter constraint
+      set('ac_g', '');
+      if(Array.isArray(data.long_count)){
+        set('ac_lc', data.long_count.join('.'));
+      } else if(typeof data.long_count === 'string') {
+        set('ac_lc', data.long_count);
+      }
+      set('ac_yb', `${data.year_bearer_value} ${data.year_bearer_name}`);
+      set('ac_819s', data.cycle819_station);
+      set('ac_819v', data.cycle819_value);
+      set('ac_dc', data.dir_color_str);
+      flashStatus('Autocorr example derived from JDN');
+    } catch(e){
+      flashStatus('Failed to load composite for JDN');
+    }
+  }
+  if(jdnInput && jdnInput.value){
+    loadFromJdn(jdnInput.value.trim());
+    return;
+  }
+  // If no JDN provided yet, pick a conversion example JDN first then derive from it.
+  const exampleJdns = ['2451545','2440588','584283','1872000','2305447'];
+  const pick = _pickExample('autocorr', exampleJdns);
+  if(pick){
+    if(jdnInput) jdnInput.value = pick;
+    loadFromJdn(pick);
+  }
+}
+function fillSyncRangeExample(){
+  const f = document.getElementById('syncRangeForm');
+  if(!f) return;
+  const examples = [
+    {start:'2451545', end:'2451700', tz:'Imix', limit:'5', fields:'jdn,gregorian_date,tzolkin_name,long_count'},
+    {start:'584283', end:'584500', tz:'Ik', limit:'8', fields:'jdn,gregorian_date,haab_month_name,long_count'},
+    {start:'1872000', end:'1872120', tz:'Ahau', limit:'10', fields:'jdn,gregorian_date,tzolkin_value,tzolkin_name'},
+    {start:'2305447', end:'2305600', tz:'Ben', limit:'6', fields:'jdn,gregorian_date,year_bearer_name,long_count'}
+  ];
+  const pick = _pickExample('sync', examples);
+  if(!pick) return;
+  const set=(n,v)=>{ const el=f.querySelector(`[name="${n}"]`); if(el) el.value=v; };
+  set('r_start', pick.start);
+  set('r_end', pick.end);
+  set('r_tzname', pick.tz);
+  set('r_limit', pick.limit);
+  set('r_fields', pick.fields);
+  flashStatus('Sync range example loaded');
+}
+
+// --- Live Gregorian date preview for JDN field ---
+let _jdnPreviewTimer = null;
+async function _fetchGregorian(jdn){
+  try {
+    const resp = await fetch(`/api/convert?jdn=${jdn}`);
+    if(!resp.ok) return null;
+    const data = await resp.json();
+    return data.gregorian_date;
+  } catch { return null; }
+}
+function attachJdnPreview(){
+  const input = document.getElementById('jdn');
+  if(!input) return;
+  let preview = document.getElementById('jdnGregorianPreview');
+  if(!preview){
+    preview = document.createElement('div');
+    preview.id='jdnGregorianPreview';
+    preview.style.fontSize='.65rem';
+    preview.style.marginTop='.2rem';
+    preview.style.color='var(--color-text-soft)';
+    input.parentElement.appendChild(preview);
+  }
+  const update = ()=>{
+    const v = input.value.trim();
+    if(!v){ preview.textContent=''; return; }
+    if(_jdnPreviewTimer) clearTimeout(_jdnPreviewTimer);
+    _jdnPreviewTimer = setTimeout(async ()=>{
+      const g = await _fetchGregorian(v);
+      preview.textContent = g ? `Gregorian: ${g}` : '';
+    }, 300);
+  };
+  input.addEventListener('input', update);
+  // initial if pre-populated
+  if(input.value) update();
+}
+document.addEventListener('DOMContentLoaded', attachJdnPreview);
+async function pollStatus(){
+  if(!activeJobId){ return; }
+  try {
+    const resp = await fetch(`/api/range-jobs/${activeJobId}`);
+    if(!resp.ok){ throw new Error('Status ' + resp.status); }
+    const data = await resp.json();
+    renderJobStatus(data);
+    if(['completed','error','canceled'].includes(data.status)){
+      clearInterval(pollTimer); pollTimer=null;
+    }
+  } catch(e){
+    console.warn('Poll failed', e);
+  }
+}
+async function stopActiveJob(){
+  if(!activeJobId) return;
+  try {
+    const resp = await fetch(`/api/range-jobs/${activeJobId}/cancel`, {method:'POST'});
+    if(resp.ok){
+      const data = await resp.json();
+      renderJobStatus(data);
+    }
+  } finally {
+    if(pollTimer){ clearInterval(pollTimer); pollTimer=null; }
+    const stopBtn = document.getElementById('btnStopJob');
+    if(stopBtn){ stopBtn.disabled = true; }
+  }
+}
+function renderJobError(msg){
+  const box = document.getElementById('rangeJobBox');
+  box.innerHTML = `<div style="color:var(--color-danger);">${msg}</div>`;
+}
+function renderJobStatus(data){
+  const box = document.getElementById('rangeJobBox');
+  // Cache job start time for smoother elapsed updates
+  if(data.started && !activeJobStartedEpoch){ activeJobStartedEpoch = data.started; }
+  const pct = data.total ? ((data.scanned / data.total)*100).toFixed(1) : '0.0';
+  const fieldList = Array.isArray(data.fields) ? data.fields : [];
+  const rows = (data.matches||[]).map(r=>{
+    return '<tr>' + fieldList.map(f=>{
+      if(f==='jdn' && fieldList.includes('gregorian_date')){
+        return `<td>${r['jdn']} (${r['gregorian_date']||''})</td>`;
+      }
+      return `<td>${r[f]||''}</td>`;
+    }).join('') + '</tr>';
+  }).join('');
+  const elapsedStr = (typeof data.elapsed === 'number') ? data.elapsed.toFixed(2) : '';
+  const startVal = (data.start !== undefined && data.start !== null) ? data.start : (data.range_start !== undefined ? data.range_start : '—');
+  const endVal = (data.end !== undefined && data.end !== null) ? data.end : (data.range_end !== undefined ? data.range_end : '—');
+  const stepVal = (data.step !== undefined && data.step !== null) ? data.step : (data.step_size !== undefined ? data.step_size : '—');
+  box.innerHTML = `
+    <div style="display:flex; align-items:center; gap:.75rem; margin-bottom:.5rem; flex-wrap:wrap;">
+      <strong>Job ${data.id}</strong>
+      <span>Status: ${data.status}</span>
+      <span>Scanned: ${data.scanned}/${data.total}</span>
+      <span>Matches: ${data.count}</span>
+      <span>${pct}%</span>
+  ${data.status==='running'?'<button type="button" onclick="stopActiveJob()">Stop</button>':''}
+    </div>
+    <div class="pbar-wrap" aria-label="Progress" style="margin-bottom:.55rem;">
+      <div class="pbar ${['completed','canceled','error'].includes(data.status)?'pbar-done pbar-static':''}" style="width:${pct}%">${pct}%</div>
+    </div>
+    <div class="job-meta" style="font-size:.6rem; opacity:.75; margin:-.35rem 0 .55rem; display:flex; gap:1rem; flex-wrap:wrap;">
+  <span>Start: <span id="jobMetaStart">${startVal}</span></span>
+  <span>End: <span id="jobMetaEnd">${endVal}</span></span>
+  <span>Step: <span id="jobMetaStep">${stepVal}</span></span>
+      <span>Limit: ${data.limit || '∞'}</span>
+      <span>Elapsed: <span id="jobMetaElapsed">${elapsedStr}</span>s</span>
+      ${data.partial ? '<span style="color:var(--color-warning); font-weight:600;">Partial</span>' : ''}
+    </div>
+    <div style="max-height:260px; overflow:auto; border:1px solid #2f3c49; border-radius:6px;">
+      <table style="border-collapse:collapse; width:100%; font-size:.7rem;">
+  <thead><tr>${fieldList.map(f=>`<th style='text-align:left; padding:.3rem .45rem; border-bottom:1px solid #3a4b5a;'>${f}</th>`).join('')}</tr></thead>
+  <tbody>${rows || '<tr><td style="padding:.4rem;" colspan="'+(fieldList.length||1)+'">(no matches yet)</td></tr>'}</tbody>
+      </table>
+    </div>
+  `;
+}
+function startElapsedLoop(){
+  if(elapsedTimer){ clearInterval(elapsedTimer); elapsedTimer=null; }
+  if(!activeJobStartedEpoch) return;
+  elapsedTimer = setInterval(()=>{
+    const el = document.getElementById('jobMetaElapsed');
+    if(!el){ return; }
+    // Stop updating if job finished
+    const jobDone = !['pending','running'].includes(document.getElementById('rangeJobBox')?.textContent.includes('Status: running') ? 'running' : '');
+    if(jobDone && pollTimer === null){ clearInterval(elapsedTimer); elapsedTimer=null; return; }
+    const now = Date.now()/1000;
+    const delta = now - activeJobStartedEpoch;
+    if(delta >= 0){ el.textContent = delta.toFixed(2); }
+  }, 250);
+}
+document.addEventListener('DOMContentLoaded', ()=>{
+  const asyncForm = document.getElementById('asyncRangeForm');
+  if(asyncForm){ asyncForm.addEventListener('submit', startRangeJob); }
+});
 </script>
 </head>
 <body>
@@ -306,6 +638,13 @@ async function runAutocorr(){
     </select>
   </div>
   <div>
+    <label for="culture">Culture (Year Bearer)</label>
+    <select id="culture" name="culture">
+      <option value="maya" {% if culture == 'maya' %}selected{% endif %}>Maya</option>
+      <option value="aztec" {% if culture == 'aztec' %}selected{% endif %}>Aztec</option>
+    </select>
+  </div>
+  <div>
     <label for="ybm">Year Bearer Month</label>
     <input type="number" id="ybm" name="ybm" min="0" max="18" value="{{ ybm if ybm is not none else '' }}" />
   </div>
@@ -319,10 +658,12 @@ async function runAutocorr(){
   <button type="button" onclick="saveCorrections()">Save Corrections</button>
   <button type="button" onclick="resetCorrections()">Reset Saved</button>
   <button type="button" onclick="resetToDefaults()">Defaults</button>
+  <button type="button" onclick="fillConvertExample()">Example</button>
   <button type="button" id="themeToggle" onclick="toggleTheme()" style="margin-left:auto;">Light Mode</button>
   </div>
 </form>
-<details style="margin-bottom:1.25rem; background:#fff; padding:1rem 1.25rem; border:1px solid #ccc; border-radius:8px;">
+<p style="margin-top:-1.2rem; font-size:.7rem; color:var(--color-text-soft);">Aztec mode subtracts 364 days before deriving the Year Bearer, shifting numbering vs Maya.</p>
+<details style="margin-bottom:1.25rem; padding:1rem 1.25rem; border-radius:8px;">
   <summary style="font-weight:600; cursor:pointer;">Corrections & Offsets</summary>
   <form method="get" action="/" style="margin-top:.8rem; display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr)); gap:.75rem;">
     <input type="hidden" name="jdn" value="{{ comp.jdn if comp else '' }}" />
@@ -339,9 +680,9 @@ async function runAutocorr(){
     </div>
   </form>
 </details>
-<section style="margin-bottom:1.5rem; background:#fff; padding:1rem 1.25rem; border:1px solid #ccc; border-radius:8px;">
-  <h2 style="margin-top:0">Derive Auto-Corrections</h2>
-  <p style="margin-top:.25rem; font-size:.9rem; color:#444;">Provide any known calendar expressions for this JDN and fetch suggested correction offsets.</p>
+<section class="panel" style="margin-bottom:1.5rem; padding:1rem 1.25rem;">
+  <h2>Derive Auto-Corrections</h2>
+  <p style="margin-top:.25rem; font-size:.9rem;">Provide any known calendar expressions (enter only what you know). Long Count must be full or 5-part (auto‑prepends baktun). Errors now show precise cause.</p>
   <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(170px,1fr)); gap:.6rem;">
     <label style="font-weight:500;">Tzolkin<br><input id="ac_tz" placeholder="e.g. 11 Ik" /></label>
     <label style="font-weight:500;">Haab<br><input id="ac_h" placeholder="e.g. 0 Pop" /></label>
@@ -353,15 +694,101 @@ async function runAutocorr(){
     <label style="font-weight:500;">Dir Color<br><input id="ac_dc" placeholder="Este Rojo" /></label>
   </div>
   <div style="margin-top:.75rem;">
-    <button type="button" onclick="runAutocorr()">Derive Offsets</button>
+  <button type="button" onclick="runAutocorr()">Derive Offsets</button>
+  <button type="button" onclick="fillAutocorrExample()">Example</button>
   </div>
   <pre id="ac_result" style="display:none; margin-top:1rem;"></pre>
+</section>
+<section class="panel" style="margin-bottom:1.5rem; padding:1rem 1.25rem;">
+  <h2>Range Search</h2>
+  <p style="margin-top:.25rem; font-size:.85rem;">Scan an inclusive JDN interval with optional filters. Returns first N matches (limit) in a lightweight table.</p>
+  <form id="syncRangeForm" method="get" action="/" style="display:grid; grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); gap:.6rem;">
+    <label>Start<br><input type="number" name="r_start" value="{{ request.query_params.get('r_start','') }}" required></label>
+    <label>End<br><input type="number" name="r_end" value="{{ request.query_params.get('r_end','') }}" required></label>
+    <label>Tzolkin Val<br><input type="number" name="r_tzval" value="{{ request.query_params.get('r_tzval','') }}" min="1" max="13"></label>
+    <label>Tzolkin Name<br><input name="r_tzname" placeholder="Imix" value="{{ request.query_params.get('r_tzname','') }}"></label>
+    <label>Haab Day<br><input type="number" name="r_haab_day" value="{{ request.query_params.get('r_haab_day','') }}" min="0" max="19"></label>
+    <label>Haab Month<br><input name="r_haab_month" placeholder="Pop" value="{{ request.query_params.get('r_haab_month','') }}"></label>
+    <label>Year Bearer Name<br><input name="r_year_bearer_name" placeholder="Ix" value="{{ request.query_params.get('r_year_bearer_name','') }}"></label>
+    <label>Dir/Color<br><input name="r_dir_color" placeholder="Este" value="{{ request.query_params.get('r_dir_color','') }}"></label>
+    <label>Weekday (1-7)<br><input type="number" name="r_weekday" value="{{ request.query_params.get('r_weekday','') }}" min="1" max="7"></label>
+    <label>Long Count Pattern<br><input name="r_long_count" placeholder="13.*.*.*.*.*" value="{{ request.query_params.get('r_long_count','') }}"></label>
+    <label>Limit<br><input type="number" name="r_limit" value="{{ request.query_params.get('r_limit','') }}" min="0"></label>
+    <label>Step<br><input type="number" name="r_step" value="{{ request.query_params.get('r_step','1') }}" min="1"></label>
+    <label>Fields (csv)<br><input name="r_fields" placeholder="jdn,tzolkin_name" value="{{ request.query_params.get('r_fields','') }}"></label>
+    <div style="grid-column:1/-1; display:flex; gap:.6rem;">
+      <button type="submit">Search Range</button>
+      <button type="button" onclick="this.form.querySelectorAll('input').forEach(i=>{ if(i.type!=='hidden') i.value=''; });">Clear</button>
+  <button type="button" onclick="fillSyncRangeExample()">Example</button>
+    </div>
+  </form>
+  {% if range %}
+  <p style="font-size:.75rem; margin-top:.6rem; color:var(--color-text-soft);">Matches: {{ range.count }} (scanned {{ range.scanned }})</p>
+    {% if range.rows %}
+      <div style="overflow:auto; max-height:300px; border:1px solid var(--color-border); border-radius:6px;">
+        <table class="alt-table" style="font-size:.78rem;">
+          <thead style="position:sticky; top:0;">
+            <tr>
+              {% for f in range_fields %}<th>{{ f }}</th>{% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in range.rows %}
+              <tr>
+                {% for f in range_fields %}
+                  <td style="font-family:ui-monospace,monospace;">
+                    {% if f == 'jdn' and 'gregorian_date' in range_fields %}
+                      {{ row['jdn'] }} ({{ row['gregorian_date'] }})
+                    {% else %}
+                      {{ row[f] }}
+                    {% endif %}
+                  </td>
+                {% endfor %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p style="font-size:.75rem; color:#777;">No matches.</p>
+    {% endif %}
+  {% endif %}
+  <p class="note" style="margin-top:.6rem;">Wildcard '*' allowed in Long Count pattern segments. Step reduces computations (e.g. 5 scans every 5th day). Empty limit scans entire span.</p>
+</section>
+<section class="panel" style="margin-bottom:1.5rem; padding:1rem 1.25rem;">
+  <h2>Async Range Search (Cancelable)</h2>
+  <p style="margin-top:.25rem; font-size:.8rem;">Launch a background job for large spans. Progress updates live; you can cancel anytime.</p>
+  <form id="asyncRangeForm" style="display:grid; grid-template-columns:repeat(auto-fill,minmax(140px,1fr)); gap:.55rem; margin-bottom:.8rem;">
+    <label>Start<br><input name="r_start" required></label>
+    <label>End<br><input name="r_end" required></label>
+    <label>Step<br><input name="r_step" value="1"></label>
+    <label>Limit<br><input name="r_limit" placeholder="0=none"></label>
+    <label>Tz Val<br><input name="r_tzval"></label>
+    <label>Tz Name<br><input name="r_tzname" placeholder="Imix"></label>
+    <label>Haab Day<br><input name="r_haab_day"></label>
+    <label>Haab Month<br><input name="r_haab_month" placeholder="Pop"></label>
+    <label>Year Bearer<br><input name="r_year_bearer_name" placeholder="Ix"></label>
+    <label>Dir Color<br><input name="r_dir_color" placeholder="Este"></label>
+    <label>Weekday<br><input name="r_weekday" placeholder="1-7"></label>
+    <label>Long Count<br><input name="r_long_count" placeholder="13.*.*.*.*.*"></label>
+    <label>Fields<br><input name="r_fields" placeholder="jdn,tzolkin_name"></label>
+    <div style="grid-column:1/-1; display:flex; gap:.6rem;">
+      <button type="submit">Search Range</button>
+      <button type="button" onclick="this.form.reset()">Reset</button>
+  <button type="button" onclick="fillAsyncExample()">Example</button>
+    </div>
+  </form>
+  <div style="margin-bottom:.6rem; display:flex; gap:.6rem;">
+    <button id="btnStopJob" type="button" class="danger" onclick="stopActiveJob()" disabled>Stop Current Job</button>
+  </div>
+  <div id="rangeJobBox" style="font-size:.75rem;">No job yet.</div>
 </section>
 {% if error %}<div class="error">Error: {{ error }}</div>{% endif %}
 {% if comp %}
 <section>
   <h2>Results</h2>
   <div class="grid">
+    <div class="card"><h3>JDN / Gregorian</h3><div class="value">{{ comp.jdn }} ({{ comp.gregorian_date }})</div></div>
     <div class="card"><h3>Tzolkin</h3><div class="value">{{ comp.tzolkin_value }} {{ comp.tzolkin_name }}</div></div>
     <div class="card"><h3>Haab</h3><div class="value">{{ comp.haab_day }} {{ comp.haab_month_name }}</div></div>
     <div class="card"><h3>Long Count</h3><div class="value">{{ comp.long_count }}</div></div>

--- a/pohualli/webapp.py
+++ b/pohualli/webapp.py
@@ -9,21 +9,262 @@ from .autocorr import derive_auto_corrections
 from .types import DEFAULT_CONFIG, ABSOLUTE, CORRECTIONS
 from .correlations import list_presets, apply_preset, active_preset_name
 from pathlib import Path
+from pydantic import BaseModel
+import threading, uuid, time, logging, os
+
+logger = logging.getLogger("pohualli")
+if not logger.handlers:
+    logging.basicConfig(level=logging.INFO)
+
+# ---------------- Range Search Async Job Management -----------------
+class RangeJob:
+    def __init__(self, params: dict):
+        # Identity & original parameters
+        self.id: str = params['id']
+        self.params: dict = params
+
+        # Promoted frequently accessed params
+        self.start: int | None = params.get('start')
+        self.end: int | None = params.get('end')
+        self.step: int | None = params.get('step')
+
+        # Lifecycle / status
+        self.status: str = 'pending'
+        self.error: str | None = None
+        self.canceled: bool = False
+        self.started: float = time.time()
+        self.ended: float | None = None
+
+        # Progress & limits
+        self.scanned: int = 0
+        self.total: int = int(params.get('total', 0))
+        self.limit: int = int(params.get('limit', 0))
+
+        # Result shaping
+        self.fields: list[str] = list(params.get('fields', []))
+        self.matches: list[dict] = []
+
+        # Execution thread
+        self.thread: threading.Thread | None = None
+
+    def to_dict(self) -> dict:
+        elapsed = (self.ended or time.time()) - self.started
+        base = {
+            'id': self.id,
+            'status': self.status,
+            'error': self.error,
+            'scanned': self.scanned,
+            'total': self.total,
+            'matches': self.matches,
+            'count': len(self.matches),
+            'fields': self.fields,
+            'limit': self.limit,
+            'canceled': self.canceled,
+            'elapsed': elapsed,
+            'partial': self.status == 'canceled' and self.scanned < self.total,
+            'start': self.start,
+            'end': self.end,
+            'step': self.step,
+            'started': self.started,
+            'ended': self.ended,
+        }
+        # Legacy alternate keys for front-end fallback
+        base['range_start'] = base['start']
+        base['range_end'] = base['end']
+        base['step_size'] = base['step']
+        return base
+
+JOBS: dict[str, RangeJob] = {}
+JOBS_LOCK = threading.Lock()
+
+def _early_filters(jdn: int, p: dict) -> bool:
+    # Early cheap filters using primitive functions
+    from . import (
+        julian_day_to_tzolkin_value, julian_day_to_tzolkin_name_index,
+        tzolkin_number_to_name, julian_day_to_haab_packed, unpack_haab_month,
+        unpack_haab_value, haab_number_to_name, julian_day_to_long_count,
+        year_bearer_packed, tzolkin_number_to_name as _tzname
+    )
+    tz_val = p.get('tz_val')
+    tz_name_l = p.get('tz_name_l')
+    haab_day = p.get('haab_day')
+    haab_month_l = p.get('haab_month_l')
+    yb_name_l = p.get('yb_name_l')
+    lc_pattern = p.get('lc_pattern')
+    if tz_val or tz_name_l:
+        v = julian_day_to_tzolkin_value(jdn)
+        if tz_val and v != tz_val:
+            return False
+        if tz_name_l:
+            nidx = julian_day_to_tzolkin_name_index(jdn)
+            if tzolkin_number_to_name(nidx).lower() != tz_name_l:
+                return False
+    need_haab = haab_day is not None or haab_month_l or yb_name_l
+    if need_haab:
+        packed = julian_day_to_haab_packed(jdn)
+        m = unpack_haab_month(packed)
+        d = unpack_haab_value(packed)
+        if haab_day is not None and d != haab_day:
+            return False
+        if haab_month_l and haab_number_to_name(m).lower() != haab_month_l:
+            return False
+        if yb_name_l:
+            yb = year_bearer_packed(m, d, jdn)
+            if _tzname(yb >> 8).lower() != yb_name_l:
+                return False
+    if lc_pattern:
+        lc = julian_day_to_long_count(jdn)
+        if len(lc_pattern) != len(lc):
+            return False
+        for pat, val in zip(lc_pattern, lc):
+            if pat != '*' and pat != str(val):
+                return False
+    return True
+
+def _run_job(job: RangeJob):
+    p = job.params
+    start = p['start']; end = p['end']; step = p['step']
+    dir_color_l = p.get('dir_color_l'); weekday_i = p.get('weekday_i')
+    limit = job.limit
+    from .composite import compute_composite
+    job.status = 'running'
+    try:
+        for jdn in range(start, end+1, step):
+            if job.canceled:
+                # Respect user cancellation; do not overwrite status later
+                break
+            job.scanned += 1
+            # Cooperative yield so cancellation requests can interleave; minimal overhead.
+            if job.scanned % 250 == 0:
+                time.sleep(0)  # yield GIL without significant delay
+            # Optional throttle (set POHUALLI_RANGE_THROTTLE microseconds) for testing cancellation determinism
+            if THROTTLE_US:
+                time.sleep(THROTTLE_US / 1_000_000.0)
+            if not _early_filters(jdn, p):
+                continue
+            comp = compute_composite(jdn)
+            if dir_color_l and dir_color_l not in comp.dir_color_str.lower():
+                continue
+            if weekday_i and comp.iso_weekday != weekday_i:
+                continue
+            row = {}
+            for f in job.fields:
+                v = getattr(comp, f, '')
+                if isinstance(v, (list, tuple)):
+                    v = '.'.join(str(x) for x in v)
+                row[f] = v
+            job.matches.append(row)
+            if limit and len(job.matches) >= limit:
+                break
+        if not job.canceled and job.status != 'canceled':
+            job.status = 'completed'
+    except Exception as e:  # pragma: no cover (rare)
+        job.error = str(e)
+        job.status = 'error'
+    finally:
+        job.ended = time.time()
+
 
 app = FastAPI(title="Pohualli Calendar API")
 
+# Read optional throttle env once (int microseconds); keep small (e.g., 200) during tests to allow cancel window
+try:
+    THROTTLE_US = int(os.environ.get('POHUALLI_RANGE_THROTTLE','0'))
+except ValueError:
+    THROTTLE_US = 0
+
 templates = Jinja2Templates(directory=str(Path(__file__).parent / 'templates'))
+
+class RangeJobRequest(BaseModel):
+    start: int
+    end: int
+    step: int = 1
+    limit: int = 0
+    tzolkin_value: int | None = None
+    tzolkin_name: str | None = None
+    haab_day: int | None = None
+    haab_month: str | None = None
+    year_bearer_name: str | None = None
+    dir_color: str | None = None
+    weekday: int | None = None
+    long_count: str | None = None
+    fields: str | None = None
+
+@app.post('/api/range-jobs')
+async def create_range_job(req: RangeJobRequest):
+    start = req.start; end = req.end; step = req.step; limit = req.limit
+    if end < start:
+        start, end = end, start
+    step = step if step > 0 else 1
+    lc_pattern = req.long_count.split('.') if req.long_count else None
+    default_fields = ['jdn','gregorian_date','tzolkin_value','tzolkin_name','haab_day','haab_month_name','long_count','year_bearer_name','dir_color_str']
+    fld_list = [f.strip() for f in (req.fields.split(',') if req.fields else default_fields) if f.strip()]
+    total = ((end - start)//step)+1
+    jid = uuid.uuid4().hex[:12]
+    params = {
+        'id': jid,
+        'start': start,
+        'end': end,
+        'step': step,
+        'tz_val': req.tzolkin_value,
+        'tz_name_l': req.tzolkin_name.lower() if req.tzolkin_name else None,
+        'haab_day': req.haab_day,
+        'haab_month_l': req.haab_month.lower() if req.haab_month else None,
+        'yb_name_l': req.year_bearer_name.lower() if req.year_bearer_name else None,
+        'dir_color_l': req.dir_color.lower() if req.dir_color else None,
+        'weekday_i': req.weekday,
+        'lc_pattern': lc_pattern,
+        'limit': limit,
+        'fields': fld_list,
+        'total': total,
+    }
+    job = RangeJob(params)
+    with JOBS_LOCK:
+        JOBS[jid] = job
+    t = threading.Thread(target=_run_job, args=(job,), daemon=True)
+    job.thread = t
+    t.start()
+    return job.to_dict()
+
+@app.get('/api/range-jobs/{jid}')
+async def get_range_job(jid: str):
+    job = JOBS.get(jid)
+    if not job:
+        return JSONResponse({'error':'not found'}, status_code=404)
+    return job.to_dict()
+
+@app.post('/api/range-jobs/{jid}/cancel')
+async def cancel_range_job(jid: str):
+    job = JOBS.get(jid)
+    if not job:
+        return JSONResponse({'error':'not found'}, status_code=404)
+    # Mark cancellation and snapshot current state immediately.
+    job.canceled = True
+    # If currently running, mark status canceled now so client gets partial results without waiting loop break.
+    if job.status in ('pending','running'):
+        # Mark as canceled; partial flag derived in to_dict when scanned < total
+        job.status = 'canceled'
+        job.ended = time.time()
+    return job.to_dict()
+
+@app.get('/api/range-jobs')
+async def list_range_jobs():
+    with JOBS_LOCK:
+        return [j.to_dict() for j in JOBS.values()]
 
 @app.get('/api/convert')
 async def api_convert(jdn: int = Query(..., description="Julian Day Number"),
                       new_era: int | None = None,
                       year_bearer_month: int | None = None,
-                      year_bearer_day: int | None = None):
+                      year_bearer_day: int | None = None,
+                      culture: str | None = Query(None, description="maya or aztec year bearer mode")):
     if new_era is not None:
         ABSOLUTE.new_era = new_era
     if year_bearer_month is not None and year_bearer_day is not None:
         DEFAULT_CONFIG.year_bearer_str = year_bearer_month
         DEFAULT_CONFIG.year_bearer_val = year_bearer_day
+    if culture:
+        DEFAULT_CONFIG.t_aztec = (culture.lower() == 'aztec')
     comp = compute_composite(jdn)
     return JSONResponse(comp.to_dict())
 
@@ -40,18 +281,48 @@ async def api_derive_autocorr(jdn: int = Query(..., description="Julian Day Numb
     """Brute-force derive correction offsets given target textual specs.
     Only provide the specs you want solved; others can be omitted.
     """
-    res = derive_auto_corrections(
-        jdn,
-        tzolkin=tzolkin,
-        haab=haab,
-        g_value=g,
-        long_count=long_count,
-        year_bearer=year_bearer,
-        cycle819_station=cycle819_station,
-        cycle819_value=cycle819_value,
-        dir_color=dir_color,
-    )
-    return JSONResponse(res.__dict__)
+    try:
+        res = derive_auto_corrections(
+            jdn,
+            tzolkin=tzolkin,
+            haab=haab,
+            g_value=g,
+            long_count=long_count,
+            year_bearer=year_bearer,
+            cycle819_station=cycle819_station,
+            cycle819_value=cycle819_value,
+            dir_color=dir_color,
+        )
+        return JSONResponse(res.__dict__)
+    except ValueError as ve:
+        logger.info(
+            "derive-autocorr value error jdn=%s tz=%s haab=%s g=%s lc=%s yb=%s st=%s val=%s dir=%s -> %s",
+            jdn,
+            tzolkin,
+            haab,
+            g,
+            long_count,
+            year_bearer,
+            cycle819_station,
+            cycle819_value,
+            dir_color,
+            ve,
+        )
+        return JSONResponse({'error': str(ve)}, status_code=400)
+    except Exception as e:  # pragma: no cover
+        logger.exception(
+            "derive-autocorr internal error jdn=%s tz=%s haab=%s g=%s lc=%s yb=%s st=%s val=%s dir=%s",
+            jdn,
+            tzolkin,
+            haab,
+            g,
+            long_count,
+            year_bearer,
+            cycle819_station,
+            cycle819_value,
+            dir_color,
+        )
+        return JSONResponse({'error': 'internal error', 'detail': str(e)}, status_code=500)
 
 @app.get('/health')
 async def health():
@@ -60,7 +331,7 @@ async def health():
 @app.get('/', response_class=HTMLResponse)
 async def home(
     request: Request,
-    jdn: int | None = None,
+    jdn: str | None = None,
     # Accept optional numeric query params as strings so blank values ("") don't raise validation errors
     new_era: str | None = None,
     ybm: str | None = None,
@@ -74,6 +345,21 @@ async def home(
     week_off: str | None = None,
     c819s: str | None = None,
     c819d: str | None = None,
+    culture: str | None = None,
+    # Range search params (prefixed to avoid collision)
+    r_start: str | None = None,
+    r_end: str | None = None,
+    r_tzval: str | None = None,
+    r_tzname: str | None = None,
+    r_haab_day: str | None = None,
+    r_haab_month: str | None = None,
+    r_year_bearer_name: str | None = None,
+    r_dir_color: str | None = None,
+    r_weekday: str | None = None,
+    r_long_count: str | None = None,
+    r_limit: str | None = None,
+    r_step: str | None = None,
+    r_fields: str | None = None,
 ):
     def _opt_int(v: str | None) -> int | None:
         if v is None or v == "":
@@ -85,6 +371,7 @@ async def home(
     error = None
     comp = None
     new_era_i = _opt_int(new_era)
+    jdn_i = _opt_int(jdn)
     ybm_i = _opt_int(ybm)
     ybd_i = _opt_int(ybd)
     if new_era_i is not None:
@@ -122,11 +409,81 @@ async def home(
         DEFAULT_CONFIG.cycle819_station_correction = c819s_i
     if c819d_i is not None:
         DEFAULT_CONFIG.cycle819_dir_color_correction = c819d_i
-    if jdn is not None and error is None:
+    # Compute single date composite if requested
+    if jdn_i is not None and error is None:
         try:
-            comp = compute_composite(jdn).to_dict()
-        except Exception as e:  # broad catch for UI feedback
+            comp = compute_composite(jdn_i).to_dict()
+        except Exception as e:
             error = str(e)
+    # Range search (independent of single conversion)
+    range_results = None
+    range_fields = None
+    if (r_start not in (None, "")) and (r_end not in (None, "")) and error is None:
+        rs: int | None = None
+        re_: int | None = None
+        try:
+            rs = int(r_start); re_ = int(r_end)
+        except ValueError:
+            error = "Invalid range start/end"
+        if error is None and rs is not None and re_ is not None:
+            if rs > re_:
+                rs, re_ = re_, rs
+            step_i = _opt_int(r_step) or 1
+            tz_val_i = _opt_int(r_tzval)
+            tz_name_l = r_tzname.lower() if r_tzname else None
+            haab_day_i = _opt_int(r_haab_day)
+            haab_month_l = r_haab_month.lower() if r_haab_month else None
+            yb_name_l = r_year_bearer_name.lower() if r_year_bearer_name else None
+            dir_color_l = r_dir_color.lower() if r_dir_color else None
+            weekday_i = _opt_int(r_weekday)
+            lc_pattern = r_long_count.split('.') if r_long_count else None
+            limit_i = _opt_int(r_limit) or 0
+            default_fields = ['jdn','gregorian_date','tzolkin_value','tzolkin_name','haab_day','haab_month_name','long_count','year_bearer_name','dir_color_str']
+            range_fields = [f.strip() for f in (r_fields.split(',') if r_fields else default_fields) if f.strip()]
+            def match_lc(lc_tuple):
+                if not lc_pattern:
+                    return True
+                if len(lc_pattern) != len(lc_tuple):
+                    return False
+                for pat,val in zip(lc_pattern, lc_tuple):
+                    if pat != '*' and pat != str(val):
+                        return False
+                return True
+            results = []
+            scanned = 0
+            for jdn_scan in range(rs, re_+1, step_i):  # type: ignore[arg-type]
+                scanned += 1
+                comp_obj = compute_composite(jdn_scan)
+                if tz_val_i and comp_obj.tzolkin_value != tz_val_i:
+                    continue
+                if tz_name_l and comp_obj.tzolkin_name.lower() != tz_name_l:
+                    continue
+                if haab_day_i is not None and comp_obj.haab_day != haab_day_i:
+                    continue
+                if haab_month_l and comp_obj.haab_month_name.lower() != haab_month_l:
+                    continue
+                if yb_name_l and comp_obj.year_bearer_name.lower() != yb_name_l:
+                    continue
+                if dir_color_l and dir_color_l not in comp_obj.dir_color_str.lower():
+                    continue
+                if weekday_i and comp_obj.iso_weekday != weekday_i:
+                    continue
+                if not match_lc(comp_obj.long_count):
+                    continue
+                row = {}
+                for f in range_fields:
+                    v = getattr(comp_obj, f, '')
+                    if isinstance(v, (list, tuple)):
+                        v = '.'.join(str(x) for x in v)
+                    row[f] = v
+                results.append(row)
+                if limit_i and len(results) >= limit_i:
+                    break
+            range_results = {
+                'rows': results,
+                'count': len(results),
+                'scanned': scanned,
+            }
     return templates.TemplateResponse(
         request,
         'index.html',
@@ -148,5 +505,8 @@ async def home(
             'error': error,
             'presets': list_presets(),
             'active_preset': active_preset_name(),
+            'culture': 'aztec' if DEFAULT_CONFIG.t_aztec else 'maya',
+            'range': range_results,
+            'range_fields': range_fields,
         }
     )

--- a/tests/test_async_cancel_partial.py
+++ b/tests/test_async_cancel_partial.py
@@ -1,0 +1,38 @@
+import os, time
+os.environ.setdefault('POHUALLI_RANGE_THROTTLE','300')  # ensure job not instantaneous
+from fastapi.testclient import TestClient
+from pohualli.webapp import app
+
+client = TestClient(app)
+
+def test_async_cancel_partial_results():
+    payload = {
+        "start": 2451545,
+        "end": 2452545,  # large span to allow cancellation
+        "step": 1,
+        "limit": 0,
+        "fields": "jdn,tzolkin_name"
+    }
+    r = client.post('/api/range-jobs', json=payload)
+    assert r.status_code == 200
+    jid = r.json()['id']
+    # Immediately cancel
+    c = client.post(f'/api/range-jobs/{jid}/cancel')
+    assert c.status_code == 200
+    data = c.json()
+    # Accept immediate transitional or final state
+    assert data['status'] in ('canceling','canceled')
+    if data['status'] == 'canceled':
+        # Full payload expected
+        assert data['scanned'] <= data['total']
+        assert 'partial' in data and data['partial'] is True
+    else:
+        # Poll briefly for final state
+        for _ in range(40):  # up to ~2s
+            s = client.get(f'/api/range-jobs/{jid}')
+            jd = s.json()
+            if jd.get('status') in ('canceled','completed','error'):
+                # We asked to cancel; allow completed if it finished just before cancellation
+                assert jd['status'] in ('canceled','completed')
+                break
+            time.sleep(0.05)

--- a/tests/test_async_range_job.py
+++ b/tests/test_async_range_job.py
@@ -1,0 +1,37 @@
+import time
+from fastapi.testclient import TestClient
+from pohualli.webapp import app
+
+client = TestClient(app)
+
+def test_async_range_job_lifecycle():
+    # Create a small job so it finishes quickly
+    payload = {
+        "start": 2451545,
+        "end": 2451555,
+        "step": 1,
+        "limit": 5,
+        "fields": "jdn,tzolkin_name,haab_month_name"
+    }
+    r = client.post('/api/range-jobs', json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    jid = data['id']
+    assert data['status'] in ("pending","running","completed")
+
+    # Poll until completion (should be fast)
+    for _ in range(60):  # up to ~3s
+        sr = client.get(f'/api/range-jobs/{jid}')
+        assert sr.status_code == 200
+        jd = sr.json()
+        if jd['status'] in ('completed','error','canceled'):
+            # basic invariants
+            assert jd['scanned'] > 0
+            assert jd['count'] <= 5
+            assert len(jd['matches']) == jd['count']
+            assert jd['fields'][:3] == ['jdn','tzolkin_name','haab_month_name']
+            assert jd['status'] == 'completed', jd
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError('Job did not finish in time')

--- a/tests/test_cli_search_range.py
+++ b/tests/test_cli_search_range.py
@@ -1,0 +1,48 @@
+import io, json
+from contextlib import redirect_stdout
+from pohualli.cli import main
+
+
+def run_cli(argv):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main(argv)
+    return buf.getvalue()
+
+
+def test_search_range_basic_header_and_rows():
+    out = run_cli(["search-range", "584283", "584290", "--limit", "3", "--tzolkin-name", "Imix"])  # small span
+    lines = [l for l in out.strip().splitlines() if l and not l.startswith('#')]
+    assert len(lines) >= 2  # header + at least one row
+    header = lines[0].split('\t')
+    assert 'jdn' in header and 'tzolkin_name' in header
+    # Check the filtered tzolkin name appears only as Imix in data lines
+    for row in lines[1:]:
+        cols = row.split('\t')
+        # map header -> value
+        mapping = dict(zip(header, cols))
+        assert mapping['tzolkin_name'] == 'Imix'
+
+
+def test_search_range_json_lines_mode():
+    out = run_cli(["search-range", "584283", "584285", "--json-lines", "--limit", "1"])  # small
+    # Should be exactly one JSON object line (match count 1)
+    lines = [l for l in out.strip().splitlines() if l]
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert 'jdn' in data and 'tzolkin_name' in data
+
+
+def test_search_range_long_count_wildcard():
+    # Look for a famous base date around correlation new era; wildcard pattern for later digits
+    out = run_cli(["search-range", "584280", "584300", "--long-count", "0.*.*.*.*.*", "--limit", "1"])
+    # Expect at least header + maybe row or # no matches; assert not crashing
+    assert 'jdn' in out or '# no matches' in out
+
+
+def test_search_range_fields_subset():
+    out = run_cli(["search-range", "584283", "584285", "--fields", "jdn,tzolkin_name,haab_month_name", "--limit", "2"])
+    lines = [l for l in out.strip().splitlines() if l and not l.startswith('#')]
+    assert lines
+    header = lines[0].split('\t')
+    assert header == ['jdn','tzolkin_name','haab_month_name']


### PR DESCRIPTION
Adds asynchronous range search jobs with cancel + partial results, revamped web UI (larger progress bar, real-time metadata, dynamic examples), CLI search-range command with early filtering and performance stats, derive-autocorr error handling, culture (Maya/Aztec) toggle, and new tests: async lifecycle, cancel partial, CLI range variants. Also updates README with range search examples. Submodule excluded from commit.