### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/.github/workflows/desktop-bundles.yml
+++ b/.github/workflows/desktop-bundles.yml
@@ -57,13 +57,24 @@ jobs:
           fi
           APP_DIST_DIR="dist/Pohualli.app"
           APP_BUILD_DIR="build/pohualli/macos/app/Pohualli.app"
+          DMG_ORIG=$(ls dist/*.dmg 2>/dev/null | head -n1 || true)
+          if [ -n "$DMG_ORIG" ]; then
+            DMG_TARGET="dist/Pohualli-${VERSION}-macOS.dmg"
+            if [ "$(basename "$DMG_ORIG")" != "$(basename "$DMG_TARGET")" ]; then
+              cp "$DMG_ORIG" "$DMG_TARGET"
+            fi
+          fi
           if [ ! -d "$APP_DIST_DIR" ]; then
             if [ -d "$APP_BUILD_DIR" ]; then
               echo "Copying app bundle from build path ($APP_BUILD_DIR) to dist/";
               mkdir -p dist
               cp -R "$APP_BUILD_DIR" "$APP_DIST_DIR"
             else
-              echo "Mac app bundle not found at either $APP_DIST_DIR or $APP_BUILD_DIR" >&2
+              if [ -n "$DMG_ORIG" ]; then
+                echo "No .app bundle found but DMG present; skipping zip creation.";
+                exit 0
+              fi
+              echo "Mac app bundle not found at either $APP_DIST_DIR or $APP_BUILD_DIR, and no DMG produced." >&2
               echo "Listing build/pohualli/macos/app for diagnostics (if exists):" >&2
               find build/pohualli/macos -maxdepth 4 -type d || true
               exit 1
@@ -104,6 +115,7 @@ jobs:
           name: desktop-${{ matrix.os }}
           path: |
             dist/Pohualli-*-macOS.zip
+            dist/Pohualli-*-macOS.dmg
             dist/Pohualli-*-windows.msi
             dist/Pohualli.app/**
           if-no-files-found: warn

--- a/.github/workflows/desktop-bundles.yml
+++ b/.github/workflows/desktop-bundles.yml
@@ -55,13 +55,21 @@ jobs:
               VERSION="sha-${GITHUB_SHA::7}"
             fi
           fi
-          APP_DIR="dist/Pohualli.app"
-          if [ -d "$APP_DIR" ]; then
-            (cd dist && zip -r "Pohualli-${VERSION}-macOS.zip" Pohualli.app)
-          else
-            echo "Mac app bundle not found at $APP_DIR" >&2
-            exit 1
+          APP_DIST_DIR="dist/Pohualli.app"
+          APP_BUILD_DIR="build/pohualli/macos/app/Pohualli.app"
+          if [ ! -d "$APP_DIST_DIR" ]; then
+            if [ -d "$APP_BUILD_DIR" ]; then
+              echo "Copying app bundle from build path ($APP_BUILD_DIR) to dist/";
+              mkdir -p dist
+              cp -R "$APP_BUILD_DIR" "$APP_DIST_DIR"
+            else
+              echo "Mac app bundle not found at either $APP_DIST_DIR or $APP_BUILD_DIR" >&2
+              echo "Listing build/pohualli/macos/app for diagnostics (if exists):" >&2
+              find build/pohualli/macos -maxdepth 4 -type d || true
+              exit 1
+            fi
           fi
+          (cd dist && zip -r "Pohualli-${VERSION}-macOS.zip" Pohualli.app)
 
       - name: Prepare release asset (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/desktop-bundles.yml
+++ b/.github/workflows/desktop-bundles.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build-desktop:
@@ -43,7 +45,16 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           set -e
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            # Use PR number if available, else short SHA
+            if [ -n "${{ github.event.pull_request.number }}" ]; then
+              VERSION="pr-${{ github.event.pull_request.number }}"
+            else
+              VERSION="sha-${GITHUB_SHA::7}"
+            fi
+          fi
           APP_DIR="dist/Pohualli.app"
           if [ -d "$APP_DIR" ]; then
             (cd dist && zip -r "Pohualli-${VERSION}-macOS.zip" Pohualli.app)
@@ -57,7 +68,15 @@ jobs:
         shell: bash
         run: |
           set -e
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            if [ -n "${{ github.event.pull_request.number }}" ]; then
+              VERSION="pr-${{ github.event.pull_request.number }}"
+            else
+              VERSION="sha-${GITHUB_SHA::7}"
+            fi
+          fi
             MSI_ORIG=$(ls dist/*.msi 2>/dev/null | head -n1 || true)
           if [ -n "$MSI_ORIG" ]; then
             cp "$MSI_ORIG" "dist/Pohualli-${VERSION}-windows.msi"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-and-publish:
@@ -72,6 +73,9 @@ jobs:
     name: Build macOS Desktop Bundle
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-and-publish
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +123,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/Pohualli-*-macOS.zip
-          append_release_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -127,6 +130,9 @@ jobs:
     name: Build Windows Desktop Bundle
     runs-on: windows-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-and-publish
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,12 +95,12 @@ jobs:
           echo "Building macOS app for version $VERSION"
           briefcase create macOS
           briefcase build macOS
-          # Locate built .app (Briefcase places it under build/macOS/<App>.app)
-          APP_BUILD_PATH="build/macOS/Pohualli.app"
+          # Briefcase outputs to build/pohualli/macos/app/Pohualli.app (standard template layout)
+          APP_BUILD_PATH="build/pohualli/macos/app/Pohualli.app"
           if [ ! -d "$APP_BUILD_PATH" ]; then
             echo "Expected app bundle not found at $APP_BUILD_PATH" >&2
-            echo "Contents of build/macOS:" >&2
-            ls -l build/macOS || true
+            echo "Tree under build/pohualli:" >&2
+            find build/pohualli -maxdepth 5 -type d || true
             exit 1
           fi
           mkdir -p dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project (for now) follows simple semantic versioning (MAJOR.MINOR.PATCH).
 
+## [0.3.1] - 2025-09-08
+### Added
+- Windows desktop bundle build in release workflow (MSI attached to tagged releases).
+- macOS desktop bundle build producing zipped .app asset (previously missing).
+
+### Fixed
+- CI coverage job for Python 3.12 failing with "No data to report" by combining parallel coverage data files.
+
+### Internal
+- Release workflow enhancements now produce multi-platform (macOS ZIP, Windows MSI) assets.
+- Improved reliability of coverage reporting path for Codecov upload.
+
 ## [0.3.0] - 2025-09-05
 ### Added
 - Asynchronous range search job system (`/api/range-jobs`): create, poll, list, cancel; includes progress (scanned, total, elapsed) and partial result delivery.
@@ -150,3 +162,5 @@ No breaking API changes; new features are additive. Users can begin using `pohua
 [0.2.2]: https://github.com/muscariello/pohualli-python/releases/tag/v0.2.2
 [0.2.3]: https://github.com/muscariello/pohualli-python/releases/tag/v0.2.3
 [0.2.4]: https://github.com/muscariello/pohualli-python/releases/tag/v0.2.4
+[0.3.0]: https://github.com/muscariello/pohualli-python/releases/tag/v0.3.0
+[0.3.1]: https://github.com/muscariello/pohualli-python/releases/tag/v0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pohualli"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.10"
 description = "Python port (in progress) of the Turbo Pascal Pohualli calendrical utility"
 authors = [ { name = "Port Maintainers" } ]
@@ -70,7 +70,7 @@ author = "Port Maintainers"
 [tool.briefcase.app.pohualli]
 formal_name = "Pohualli"
 description = "Mesoamerican calendar utility (Maya and Aztec calendrics)."
-version = "0.3.0"
+version = "0.3.1"
 sources = ["pohualli"]
 main_module = "pohualli.desktop_app"
 requires = [


### PR DESCRIPTION
Release 0.3.1

Changes since 0.3.0:
- Add macOS & Windows desktop bundle build jobs to release workflow
- Fix coverage combine step for Python 3.12 CI job (resolves 'No data to report')
- Update CHANGELOG and version metadata (pyproject & Briefcase config)

Tag v0.3.1 already pushed; merging will allow future patches on top of main with updated version.