### PR TITLE
docs: align desktop and API guides with Flutter + RPC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,5 +37,6 @@ print(res.tzolkin_value, res.tzolkin_name, res.long_count)
 ## Next Steps
 
 - Read the Quick Start for end-to-end examples.
+- Read Desktop Apps for Flutter packaging and release artifacts.
 - Explore Concepts for calendar background.
 - See Python API for data structures.

--- a/docs/usage/desktop.md
+++ b/docs/usage/desktop.md
@@ -30,6 +30,23 @@ For tags `v*.*.*`, the Flutter Desktop workflow publishes:
 - macOS unsigned zip (`PohualliDesktop-<version>-macOS-unsigned.zip`) when secrets are missing
 - Windows zip (`PohualliDesktop-<version>-windows.zip`)
 
+Direct download links by release tag:
+
+- Generic pattern:
+  `https://github.com/muscariello/pohualli-python/releases/download/<tag>/<file.zip>`
+- macOS signed:
+  `https://github.com/muscariello/pohualli-python/releases/download/<tag>/PohualliDesktop-<version>-macOS.zip`
+- macOS unsigned:
+  `https://github.com/muscariello/pohualli-python/releases/download/<tag>/PohualliDesktop-<version>-macOS-unsigned.zip`
+- Windows:
+  `https://github.com/muscariello/pohualli-python/releases/download/<tag>/PohualliDesktop-<version>-windows.zip`
+
+Example for `v0.4.0`:
+
+- `https://github.com/muscariello/pohualli-python/releases/download/v0.4.0/file.zip`
+- `https://github.com/muscariello/pohualli-python/releases/download/v0.4.0/PohualliDesktop-0.4.0-macOS.zip`
+- `https://github.com/muscariello/pohualli-python/releases/download/v0.4.0/PohualliDesktop-0.4.0-windows.zip`
+
 ## macOS First Run
 
 If you install an unsigned build:

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -1,15 +1,53 @@
 # Python API
 
-Primary entry point: `compute_composite(jdn: int) -> CompositeResult`.
+Primary entry point:
+
+`compute_composite(jdn: int) -> CompositeResult`
+
+Example:
+
+```python
+from pohualli import compute_composite
+
+res = compute_composite(2451545)
+print(res.tzolkin_value, res.tzolkin_name, res.long_count)
+```
 
 `CompositeResult` includes (selected):
+
 - `tzolkin_value`, `tzolkin_name`
 - `haab_day`, `haab_month_name`
 - `long_count`
 - `year_bearer_value`, `year_bearer_name`
 - `cycle819_station`, `dir_color_str`
-- `mercury_index`, `venus_index`, etc.
+- planetary indices (`mercury_index`, `venus_index`, etc.)
 - `maya_moon_age`, `eclipse_possible`
 - `star_zodiac_deg`, `star_zodiac_name`
 
-Configuration objects live in `pohualli.types` (e.g. `DEFAULT_CONFIG`).
+Configuration objects are in `pohualli.types` (for example `DEFAULT_CONFIG`).
+
+## JSON-RPC Backend API
+
+The Flutter desktop app communicates with the backend via newline-delimited JSON-RPC over stdin/stdout.
+
+Start backend:
+
+```bash
+pohualli-rpc
+```
+
+Supported methods:
+
+- `health`
+- `list_correlations`
+- `convert`
+- `derive_autocorr`
+- `search_range`
+- `quit`
+
+Example request lines:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"health","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"convert","params":{"jdn":2451545,"culture":"maya"}}
+```

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -36,6 +36,15 @@ print(compute_composite(2451545).tzolkin_name)
 pohualli-rpc
 ```
 
-## 5. Configuration
+## 5. Flutter Desktop UI
+
+```bash
+cd flutter/pohualli_desktop
+flutter pub get
+flutter run -d macos
+# or: flutter run -d windows
+```
+
+## 6. Configuration
 
 Adjust New Era or year bearer reference via query params or CLI flags.


### PR DESCRIPTION
## Summary
- update quickstart for Flutter desktop + RPC flow
- add JSON-RPC backend section to Python API docs
- update desktop docs with release artifact URL patterns and v0.4.0 example links
- refresh docs index navigation guidance

## Files
- docs/index.md
- docs/usage/desktop.md
- docs/usage/python-api.md
- docs/usage/quickstart.md

## Validation
- docs-only update (no runtime code changes)